### PR TITLE
Waiting PawnTableOnGUI to finish before removing columns

### DIFF
--- a/Numbers/Numbers.cs
+++ b/Numbers/Numbers.cs
@@ -33,6 +33,7 @@
                 prefix: new HarmonyMethod(typeof(Numbers), nameof(RightClickToRemoveHeader)));
 
             harmony.Patch(AccessTools.Method(typeof(PawnTable), nameof(PawnTable.PawnTableOnGUI)),
+                postfix: new HarmonyMethod(typeof(Numbers), nameof(ApplyColumnsRemoval)),
                 transpiler: new HarmonyMethod(typeof(Numbers), nameof(MakeHeadersReOrderable)));
 
             harmony.Patch(AccessTools.Method(typeof(PawnColumnWorker), nameof(PawnColumnWorker.DoHeader)),
@@ -86,12 +87,20 @@
             if (!Mouse.IsOver(headerRect))
                 return true;
 
-            numbersTable.RemoveColumns(x => ReferenceEquals(__instance, x.Worker));
+            numbersTable.EnqueueColumnRemoval(x => ReferenceEquals(__instance, x.Worker));
 
             if (Find.WindowStack.currentlyDrawnWindow is MainTabWindow_Numbers numbers)
                 numbers.RefreshAndStoreSessionInWorldComp();
 
             return false;
+        }
+
+        private static void ApplyColumnsRemoval(PawnTable __instance)
+        {
+            if (__instance is PawnTable_NumbersMain table)
+            {
+                table.ApplyColumnRemoval();
+            }
         }
 
         private static IEnumerable<CodeInstruction> MakeHeadersReOrderable(IEnumerable<CodeInstruction> instructions, ILGenerator generator)

--- a/Numbers/Numbers.csproj
+++ b/Numbers/Numbers.csproj
@@ -5,10 +5,13 @@
     <Product>Numbers</Product>
     <Copyright>Copyright © Mehni 2022</Copyright>
     <FileVersion>1.1.0.0</FileVersion>
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
     <LangVersion>latest</LangVersion>
     <OutputPath>..\1.4\Assemblies\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3534" />

--- a/Numbers/PawnTable_NumbersMain.cs
+++ b/Numbers/PawnTable_NumbersMain.cs
@@ -29,7 +29,7 @@
         }
 
         // Postponing column removal until PawnTable drawing is finished
-        // Immidiate removal causes change of column indexes in middle of drawing process
+        // Immediate removal causes change of column indexes in middle of drawing process
         // it makes vanilla game to render nonsense for a single update
         // and also causes support issues for Grouped Pawn Tables mod (caches mismatch)
         public void EnqueueColumnRemoval(Predicate<PawnColumnDef> predicate)


### PR DESCRIPTION
Immediate removal causes change of column indexes in middle of drawing process
it makes vanilla game to render nonsense for a single update, and also causes error in Grouped Pawn Tables mod, because caches don't longer match actual tables in mid of the windows drawing